### PR TITLE
Restore transcript compare option

### DIFF
--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -794,20 +794,21 @@ class _GetDevToolsOptionsState extends State<GetDevToolsOptions> {
           },
         ),
       ),
-      // widget.memory.postprocessing?.status == MemoryPostProcessingStatus.completed
-      // widget.memory.postprocessing?.status != MemoryPostProcessingStatus.not_started
-      //     ? Card(
-      //         shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8))),
-      //         child: ListTile(
-      //           title: const Text('Compare Transcripts Models'),
-      //           leading: const Icon(Icons.chat),
-      //           trailing: const Icon(Icons.arrow_forward_ios, size: 20),
-      //           onTap: () {
-      //             routeToPage(context, CompareTranscriptsPage(memory: widget.memory));
-      //           },
-      //         ),
-      //       )
-      //     : const SizedBox.shrink(),
+      Card(
+        shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(8))),
+        child: ListTile(
+          title: const Text('Compare Transcripts Models'),
+          leading: const Icon(Icons.chat),
+          trailing: const Icon(Icons.arrow_forward_ios, size: 20),
+          onTap: () {
+            routeToPage(
+                context,
+                CompareTranscriptsPage(
+                    conversation: widget.conversation));
+          },
+        ),
+      ),
     ]);
   }
 }

--- a/docs/docs/get_started/introduction.mdx
+++ b/docs/docs/get_started/introduction.mdx
@@ -60,6 +60,7 @@ Simply connect Omi to your mobile device and enjoy:
 ⚡ **Instant Summarization**
 📡 **Offline Transcription**
 🌐 **App Marketplace**
+🔎 **Raw Transcript Viewer** *(Conversation Detail > Compare Transcripts Models)*
 
 ---
 


### PR DESCRIPTION
## Summary
- re-enable the Compare Transcripts card on the Conversation Details page
- document how to access raw transcripts in the docs

## Testing
- `git status -s`