### PR TITLE
Improve BLE reconnection after disconnect

### DIFF
--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -185,6 +185,10 @@ class DeviceService implements IDeviceService {
     for (var s in _subscriptions.values) {
       s.onDeviceConnectionStateChanged(deviceId, state);
     }
+
+    if (state == DeviceConnectionState.disconnected) {
+      discover(desirableDeviceId: deviceId);
+    }
   }
 
   void onDevices(List<BtDevice> devices) {

--- a/omi/firmware/devkit/src/transport.c
+++ b/omi/firmware/devkit/src/transport.c
@@ -392,6 +392,15 @@ static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
         current_connection = NULL;
     }
     current_mtu = 0;
+
+    /* Restart advertising so the device is connectable after a disconnect */
+    int adv_err = bt_le_adv_start(BT_LE_ADV_CONN, bt_ad, ARRAY_SIZE(bt_ad),
+                                  bt_sd, ARRAY_SIZE(bt_sd));
+    if (adv_err) {
+        LOG_ERR("Failed to restart advertising (err %d)", adv_err);
+    } else {
+        LOG_INF("Advertising restarted");
+    }
 }
 
 static bool _le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)

--- a/omi/firmware/omi/src/lib/dk2/transport.c
+++ b/omi/firmware/omi/src/lib/dk2/transport.c
@@ -264,6 +264,15 @@ static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
         current_connection = NULL;
     }
     current_mtu = 0;
+
+    /* Restart advertising so the device becomes discoverable again */
+    int adv_err = bt_le_adv_start(BT_LE_ADV_CONN, bt_ad, ARRAY_SIZE(bt_ad),
+                                  bt_sd, ARRAY_SIZE(bt_sd));
+    if (adv_err) {
+        LOG_ERR("Failed to restart advertising (err %d)", adv_err);
+    } else {
+        LOG_INF("Advertising restarted");
+    }
 }
 
 static bool _le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)


### PR DESCRIPTION
## Summary
- restart BLE advertising on disconnect so devices remain discoverable
- apply fix to both production and devkit firmware
- rediscover and reconnect to devices when the Android app sees a BLE disconnect

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a49f7f0ab883329b9b6b6952897085